### PR TITLE
add odpay.net 88x31

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -795,6 +795,7 @@ AfnY+xdN8hTBYFURagTJlhqN4x8=
         {% else %}
             <a href="https://we-are-jammin.xyz/"><img src="/assets/88x31/jammin.webp" alt="We are jammin"></a>
         {% endif %}
+        <a href="https://odpay.net/"><img src="https://odpay.net/88x31.gif" alt="odpay.net"></a>
         <a href="https://europa.eu/"><img src="/assets/88x31/eu.png" alt="EU - United in diversity"></a>
         <a href="https://www.gesetze-im-internet.de/gg/art_1.html" title="Article 1 of the German constitution"><img src="/assets/88x31/germany.png" alt="Human dignity shall be inviolable. To respect and protect it shall be the duty of all state authority."></a>
         <a href="https://magmaus3.eu.org/"><img src="/assets/88x31/magmaus3.gif" alt="Maia"></a>


### PR DESCRIPTION
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request

## GUIDE:
How to Add the ODPAY 88x31 Webring GIF to Your Website

If you're looking to add the ODPAY 88x31 webring GIF to your website, you're in the right place! Adding the GIF to your site is a simple way to join a community of webmasters and get your site listed in the ODPAY web ring. Here’s how to do it:
What You’ll Need:

    Access to your website's HTML or a website builder that allows custom code
    The URL of the ODPAY 88x31 webring GIF: https://odpay.net/88x31.gif
    A basic understanding of how to edit HTML, or the ability to add custom HTML blocks in your website builder

Step 1: Get the URL of the ODPAY 88x31 Webring GIF

First, make sure you have the correct URL for the ODPAY 88x31 GIF. The image URL is:

https://odpay.net/88x31.gif

You’ll use this URL in your website's code to display the webring GIF.
Step 2: Decide Where You Want to Place the GIF

Consider where you want to add the webring GIF on your website. Here are a few popular options:

    Sidebar: A common spot for webring badges, usually on the side of your page.
    Footer: You can place it at the bottom of your page for visibility.
    Header: Another great spot if you want the badge to be one of the first things visitors see.
    Dedicated Page: Some people create a specific “Webrings” or “Affiliates” page to list all their webrings.

Step 3: Add the HTML Code to Your Website

You’ll need to insert a small snippet of HTML code to add the ODPAY 88x31 webring GIF to your site.
Method 1: Add Code Directly to Your HTML

If you have access to your website’s HTML code, follow these steps:

    Open your HTML editor: Go to the page where you want to add the webring.
    Insert the following code where you want the GIF to appear:

<a href="http://www.odpay.net/webring" target="_blank">
  <img src="https://odpay.net/88x31.gif" alt="ODPAY Webring" />
</a>

    <a> tag: The link that makes the GIF clickable, leading to the ODPAY webring site when clicked.
    href attribute: Replace http://www.odpay.net/webring with the exact URL of the ODPAY webring home page (this is typically the homepage for the webring).
    <img> tag: This embeds the image (the ODPAY 88x31 GIF) into your page.
    src attribute: Use the URL https://odpay.net/88x31.gif for the image.
    alt attribute: Provides an accessible description of the image for screen readers or if the image doesn’t load.

Method 2: Add the Code in a Website Builder (e.g., WordPress, Wix, etc.)

If you're using a website builder, you can still add the code by following these steps:

    Log in to your website builder.
    Navigate to the page where you want to place the GIF.
    Add a Custom HTML block or widget.
    Paste the same HTML code from Step 3 (Method 1) into the custom HTML field.
    Save and publish your changes.

Step 4: Test the Webring GIF on Your Website

Once you’ve added the code, go to your website and check:

    The GIF should appear where you placed it (e.g., in the sidebar or footer).
    When you click on the GIF, it should open the ODPAY webring page in a new tab.

If the GIF doesn’t show up, ensure you’ve copied the correct URL for the image, and double-check the HTML code.